### PR TITLE
Fractal brc20 events order

### DIFF
--- a/src/okx.rs
+++ b/src/okx.rs
@@ -177,8 +177,12 @@ impl OkxUpdater {
 
     let now = Instant::now();
     for bundle_message in bundle_messages.iter() {
-      // process brc20 operation
+      // process brc20 transfer operation
       if index.has_brc20_index() {
+        if !matches!(bundle_message.inscription_action, InscriptionAction::Transferred) {
+          continue
+        }
+
         if let Some(brc20_execution_message) =
           BRC20ExecutionMessage::new_from_bundle_message(bundle_message, context)?
         {
@@ -226,6 +230,26 @@ impl OkxUpdater {
             bundle_message.sequence_number,
             bundle_message.inscription_id,
           )?;
+        }
+      }
+    }
+
+    for bundle_message in bundle_messages.iter() {
+      // process brc20 inscribe operation
+      if index.has_brc20_index() {
+        if matches!(bundle_message.inscription_action, InscriptionAction::Transferred) {
+          continue
+        }
+
+        if let Some(brc20_execution_message) =
+          BRC20ExecutionMessage::new_from_bundle_message(bundle_message, context)?
+        {
+          if let Ok(receipt) =
+            brc20_execution_message.execute(index, context, self.height, self.timestamp)
+          {
+            brc20_execution_receipts.push(receipt);
+          }
+          continue;
         }
       }
     }


### PR DESCRIPTION
We discussed with Domo the need to determine a simple order for inscriptions in transactions, which is to process all transfers first, then inscribe.
We found that the event order implementation of ord itself leads to complex results, not only depending on the output sat offset, but also transfer always takes precedence over inscribe for the same offset. In this way, the order of events in a transaction can be a mixture of various situations.

This proposal will process brc20 events in a simple order.

ref: https://github.com/brc20-devs/brc20-proposals/blob/main/bp03-safe-reveal-transfer/proposal.md