### PR TITLE
fix: add inscribe single step transfer event

### DIFF
--- a/src/okx/brc20/event.rs
+++ b/src/okx/brc20/event.rs
@@ -12,6 +12,7 @@ pub enum BRC20OpType {
   Commit,
   TransferWithdraw,
   TransferCommit,
+  InscribeSingleStepTransfer,
 }
 
 impl From<&BRC20Operation> for BRC20OpType {
@@ -19,13 +20,17 @@ impl From<&BRC20Operation> for BRC20OpType {
     match value {
       BRC20Operation::Deploy(_) => BRC20OpType::Deploy,
       BRC20Operation::Mint { .. } => BRC20OpType::Mint,
-      BRC20Operation::InscribeTransfer{ .. } => BRC20OpType::InscribeTransfer,
       BRC20Operation::Transfer { .. } => BRC20OpType::Transfer,
       BRC20Operation::CreateModule(_) => BRC20OpType::CreateModule,
       BRC20Operation::Withdraw(_) => BRC20OpType::Withdraw,
       BRC20Operation::Commit(_) => BRC20OpType::Commit,
       BRC20Operation::TransferWithdraw(_) => BRC20OpType::TransferWithdraw,
       BRC20Operation::TransferCommit(_) => BRC20OpType::TransferCommit,
+      BRC20Operation::InscribeTransfer { signer, .. } => {
+        signer.as_ref().map_or(BRC20OpType::InscribeTransfer, |s| {
+          BRC20OpType::InscribeSingleStepTransfer
+        })
+      }
     }
   }
 }
@@ -41,6 +46,7 @@ pub enum BRC20Event {
   TransferWithdraw(TransferWithdrawEvent),
   InscribeCommit(InscribeCommitEvent),
   TransferCommit(TransferCommitEvent),
+  InscribeSingleStepTransfer(InscribeTransferEvent),
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]

--- a/src/okx/brc20/executor/inscribe_transfer.rs
+++ b/src/okx/brc20/executor/inscribe_transfer.rs
@@ -1,11 +1,9 @@
-use std::ops::Add;
-
+use super::*;
 use crate::okx::{
   brc20::{brc20_decimal::Brc20Decimal, entry::BRC20ModuleTokenBalance},
   utils::get_module_from_script,
 };
-
-use super::*;
+use std::ops::Add;
 
 impl BRC20ExecutionMessage {
   pub(super) fn execute_inscribe_transfer(
@@ -13,7 +11,7 @@ impl BRC20ExecutionMessage {
     index: &Index,
     context: &mut TableContext,
   ) -> Result<BRC20Receipt, ExecutionError> {
-    let BRC20Operation::InscribeTransfer{ signer, transfer } = &self.operation else {
+    let BRC20Operation::InscribeTransfer { signer, transfer } = &self.operation else {
       log::debug!(
         "brc20swap execute_inscribe_transfer unreachable: {:?}, inscription_id: {:?}",
         self.txid,
@@ -33,11 +31,9 @@ impl BRC20ExecutionMessage {
     let decimals = ticker_info.clone().decimals;
     let total_supply = ticker_info.clone().total_supply;
 
-    let amt = FixedPoint::new_from_str(&transfer.amount, decimals)
-      .map_err(BRC20Error::NumericError)?;
-    if amt.is_zero()
-      || amt > FixedPoint::new_unchecked(total_supply, decimals)
-    {
+    let amt =
+      FixedPoint::new_from_str(&transfer.amount, decimals).map_err(BRC20Error::NumericError)?;
+    if amt.is_zero() || amt > FixedPoint::new_unchecked(total_supply, decimals) {
       log::debug!(
         "brc20swap execute_inscribe_transfer amount invalid: {:?}, amount: {:?}",
         self.txid,
@@ -131,14 +127,13 @@ impl BRC20ExecutionMessage {
         }
         Err(_) => {}
       }
-
     }
 
     context.update_brc20_balance(&sender, &ticker, sender_balance)?;
 
     let transferring_asset = BRC20TransferAsset {
       ticker: ticker.clone(),
-      amount: amount,
+      amount,
       owner: receiver.clone(),
       sequence_number: self.sequence_number,
       inscription_number: 0,
@@ -153,6 +148,8 @@ impl BRC20ExecutionMessage {
     )?;
 
     log::debug!("brc20swap execute_inscribe_transfer finished: {:?}", self);
+
+    let event = InscribeTransferEvent { ticker, amount };
     Ok(BRC20Receipt {
       inscription_id: self.inscription_id,
       sequence_number: self.sequence_number,
@@ -160,12 +157,12 @@ impl BRC20ExecutionMessage {
       old_satpoint: self.old_satpoint,
       new_satpoint: self.new_satpoint,
       sender: sender_or_legacy,
-      receiver: receiver,
+      receiver,
       op_type: BRC20OpType::InscribeTransfer,
-      result: Ok(BRC20Event::InscribeTransfer(InscribeTransferEvent {
-        ticker,
-        amount: amount,
-      })),
+      result: Ok(match signer {
+        Some(_) => BRC20Event::InscribeSingleStepTransfer(event),
+        None => BRC20Event::InscribeTransfer(event),
+      }),
     })
   }
 }

--- a/src/subcommand/server/okx/brc20/receipt.rs
+++ b/src/subcommand/server/okx/brc20/receipt.rs
@@ -14,6 +14,7 @@ pub enum ApiTxEvent {
   Deploy(ApiDeployEvent),
   Mint(ApiMintEvent),
   InscribeTransfer(ApiInscribeTransferEvent),
+  InscribeSingleStepTransfer(ApiInscribeSingleStepTransfer),
   Transfer(ApiTransferEvent),
   CreateModule(ApiCreateModuleEvent),
   InscribeWithdraw(ApiInscribeWithdrawEvent),
@@ -67,6 +68,21 @@ impl From<BRC20Receipt> for ApiTxEvent {
           valid: true,
           tick: inscribe_transfer_event.ticker,
           amount: inscribe_transfer_event.amount.to_string(),
+          msg: "ok".to_string(),
+          event: event.op_type,
+        })
+      }
+      Ok(BRC20Event::InscribeSingleStepTransfer(inscribe_single_step_transfer_event)) => {
+        Self::InscribeSingleStepTransfer(ApiInscribeSingleStepTransfer {
+          inscription_id: event.inscription_id,
+          inscription_number,
+          old_satpoint: event.old_satpoint,
+          new_satpoint: event.new_satpoint,
+          from: event.sender.into(),
+          to: event.receiver.into(),
+          valid: true,
+          tick: inscribe_single_step_transfer_event.ticker,
+          amount: inscribe_single_step_transfer_event.amount.to_string(),
           msg: "ok".to_string(),
           event: event.op_type,
         })
@@ -232,6 +248,23 @@ pub struct ApiMintEvent {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ApiInscribeTransferEvent {
+  #[serde(rename = "type")]
+  pub event: BRC20OpType,
+  pub tick: BRC20Ticker,
+  pub inscription_id: InscriptionId,
+  pub inscription_number: u32,
+  pub old_satpoint: SatPoint,
+  pub new_satpoint: SatPoint,
+  pub amount: String,
+  pub from: ApiUtxoAddress,
+  pub to: ApiUtxoAddress,
+  pub valid: bool,
+  pub msg: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApiInscribeSingleStepTransfer {
   #[serde(rename = "type")]
   pub event: BRC20OpType,
   pub tick: BRC20Ticker,


### PR DESCRIPTION
Introduce a new event type `InscribeSingleStepTransfer` to distinguish it from the original `InscribeTransfer` type.