### PR TITLE
Update/activation height

### DIFF
--- a/src/okx/brc20/policies.rs
+++ b/src/okx/brc20/policies.rs
@@ -17,7 +17,7 @@ impl HardForks {
 
   pub fn self_single_step_transfer_activation_height(chain: &Chain) -> u32 {
     match chain {
-      Chain::Mainnet => 930000,  // decided by community
+      Chain::Mainnet => 930930,  // decided by community
       Chain::Testnet => 0, //
       Chain::Regtest => 0,
       Chain::Signet => 0,


### PR DESCRIPTION
Update Mainnet activation height to 930930 for single step transfer.